### PR TITLE
modified the generated matlab scripts to exit at the end, and modified t...

### DIFF
--- a/src/body/isosingular.cpp
+++ b/src/body/isosingular.cpp
@@ -193,7 +193,7 @@ void isosingular_deflation_iteration(int *declarations,
 	printf("\nPerforming an isosingular deflation\n");
 	
 	std::stringstream converter;
-	converter << matlab_command << " < matlab_deflate.m";
+	converter << matlab_command << "matlab_deflate";
 	system(converter.str().c_str());
 	converter.clear(); converter.str("");
 	
@@ -397,7 +397,7 @@ void createMatlabDeflation(FILE *OUT, int numVars, char **vars, int *lineVars, i
 	fprintf(OUT, "    fprintf(OUT, ',');\n");
 	fprintf(OUT, "  end;\n");
 	fprintf(OUT, "end;\n");
-	
+	fprintf(OUT, "\nexit\n");
 	// clear memory
 	free(str);
 	

--- a/src/body/nullspace.cpp
+++ b/src/body/nullspace.cpp
@@ -1094,7 +1094,7 @@ void create_nullspace_system(boost::filesystem::path output_name,
 	
 	// run Matlab script
 	std::stringstream converter;
-	converter << program_options.matlab_command() << " < matlab_nullspace_system.m";
+	converter << program_options.matlab_command() << "matlab_nullspace_system";
 	system(converter.str().c_str());
 	converter.clear(); converter.str("");
 	
@@ -1440,7 +1440,7 @@ void createMatlabDerivative(boost::filesystem::path output_name,
 	//	OUT << "    end %re: if\n";
 	//	OUT << "  end %re: kk\n";
 	OUT << "end %re: jj\n\n";
-	
+	OUT << "\nexit %exit the script\n";
 	
 	
 	

--- a/src/body/programConfiguration.cpp
+++ b/src/body/programConfiguration.cpp
@@ -388,7 +388,7 @@ void BertiniRealConfig::init()
 	stifle_membership_screen_ = true;
 	stifle_text_ = " > /dev/null ";
 	
-	matlab_command_ = "matlab -nosplash -nodesktop -nojvm";
+	matlab_command_ = "matlab -nosplash -nodesktop -nojvm -r ";
 	verbose_level(0); // default to 0
 	
 	


### PR DESCRIPTION
...he calls to matlab to be all like '-r scriptname' instead of '< scriptname.m' because the latter is not portable to cygwin.