### PR TITLE
Feature/tracking multiple vertex sources

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,9 +3,9 @@
 
 
 
-#we're building bertini_real, version 1.8.0, and the corresponding email is silviana's
+#we're building bertini_real, version 1.9.0, and the corresponding email is silviana's
 # please make sure the version number always has three entries.
-AC_INIT([bertini_real],[1.8.0],[silviana.amethyst@gmail.com],[bertini_real],[https://bertinireal.com/])
+AC_INIT([bertini_real],[1.9.0],[silviana.amethyst@gmail.com],[bertini_real],[https://bertinireal.com/])
 
 
 # Force autoconf to be at least this version number:

--- a/include/cells/vertex.hpp
+++ b/include/cells/vertex.hpp
@@ -23,6 +23,7 @@ private:
 
 	VertexType type_;  ///< See enum.
 	int input_filename_index_; ///< index into the vertex_set's vector of filenames.
+	std::vector<int> input_filename_indices_; ///< indices into the vertex_set's vector of filenames, every time it is found.  added 1.9
 	std::vector<int> path_numbers_ending_here_; ///< the integer indices of the path numbers ending at this vertex.   added v 1.8.0
 
 public:
@@ -59,6 +60,15 @@ public:
 		return input_filename_index_;
 	}
 
+	/**
+	 \brief get the indices of all systems on which this point is incident
+
+	 \return the indices
+	 */
+	inline const std::vector<int>& input_filename_indices() const
+	{
+		return input_filename_indices_;
+	}
 
 	/**
 	 \brief set the index
@@ -68,6 +78,16 @@ public:
 	void set_input_filename_index(int new_index)
 	{
 		input_filename_index_ = new_index;
+	}
+
+	/**
+	 \brief add another index, for a system on which this vertex lives
+
+	 \param new_index the new index to set in the Vertex
+	 */
+	void add_input_filename_index(int new_index)
+	{
+		input_filename_indices_.push_back(new_index);
 	}
 
 
@@ -195,6 +215,10 @@ public:
 		print_point_to_screen_matlab(pt_mp_,"point");
 		print_point_to_screen_matlab(projection_values_,"projection_values");
 		std::cout << "type: " << type_ << std::endl;
+		std::cout << "originating filename index: " << input_filename_index_ << std::endl;
+		std::cout << "all filename indices: ";
+		for (auto f: input_filename_indices_) 
+			std::cout << f << " ";
 		std::cout << "paths ending here: ";
 		for (auto p: path_numbers_ending_here_)
 			std::cout << p << " ";
@@ -280,6 +304,7 @@ private:
 		this->type_ = other.type_;
 
 		this->input_filename_index_ = other.input_filename_index_;
+		this->input_filename_indices_ = other.input_filename_indices_;
 
 		this->path_numbers_ending_here_ = other.path_numbers_ending_here_;
 	}

--- a/include/containers/vertex_set.hpp
+++ b/include/containers/vertex_set.hpp
@@ -89,6 +89,7 @@ public:
 
 
 
+	void add_current_input_index_to_vertex(unsigned int index);
 
 	/**
 	 \brief get the number of natural variables

--- a/matlab_codes/gather_br_samples.m
+++ b/matlab_codes/gather_br_samples.m
@@ -516,7 +516,7 @@ for ii = 1:BRinfo.num_vertices
     num_input_filename_indices = fscanf(fid,'%i\n',[1 1]);
     BRinfo.vertices(ii).all_input_filename_indices = zeros(num_input_filename_indices,1);
     for jj = 1:num_input_filename_indices
-        BRinfo.vertices(ii).all_input_filename_indices(jj) =  fscanf(fid,'%i',[1 1]);
+        BRinfo.vertices(ii).all_input_filename_indices(jj) =  fscanf(fid,'%i',[1 1])+1;
     end
 
 	BRinfo.vertices(ii).type = fscanf(fid,'%i',[1 1]);

--- a/matlab_codes/gather_br_samples.m
+++ b/matlab_codes/gather_br_samples.m
@@ -512,11 +512,18 @@ for ii = 1:BRinfo.num_vertices
 	end
     BRinfo.vertices(ii).input_filename_index = fscanf(fid,'%i\n',[1 1]);
 
+    
+    % this feature was introduced in v 1.9.0
+    if BRinfo.run_metadata.version.gather >= 190
+        num_input_filename_indices = fscanf(fid,'%i\n',[1 1]);
 
-    num_input_filename_indices = fscanf(fid,'%i\n',[1 1]);
-    BRinfo.vertices(ii).all_input_filename_indices = zeros(num_input_filename_indices,1);
-    for jj = 1:num_input_filename_indices
-        BRinfo.vertices(ii).all_input_filename_indices(jj) =  fscanf(fid,'%i',[1 1])+1;
+        % preallocate
+        BRinfo.vertices(ii).all_input_filename_indices = zeros(num_input_filename_indices,1);
+
+        % read into the container
+        for jj = 1:num_input_filename_indices
+            BRinfo.vertices(ii).all_input_filename_indices(jj) =  fscanf(fid,'%i',[1 1])+1; % adding 1 because matlab is 1-based, not 0-based like the c++ core is
+        end
     end
 
 	BRinfo.vertices(ii).type = fscanf(fid,'%i',[1 1]);

--- a/matlab_codes/gather_br_samples.m
+++ b/matlab_codes/gather_br_samples.m
@@ -510,7 +510,15 @@ for ii = 1:BRinfo.num_vertices
 		tmp = fscanf(fid,'%e %e\n',[1 2]);
 		BRinfo.vertices(ii).projection_value(jj) = tmp(1)+1i*tmp(2);
 	end
-    BRinfo.vertices(ii).input_filename_index = fscanf(fid,'%i',[1 1]);
+    BRinfo.vertices(ii).input_filename_index = fscanf(fid,'%i\n',[1 1]);
+
+
+    num_input_filename_indices = fscanf(fid,'%i\n',[1 1]);
+    BRinfo.vertices(ii).all_input_filename_indices = zeros(num_input_filename_indices,1);
+    for jj = 1:num_input_filename_indices
+        BRinfo.vertices(ii).all_input_filename_indices(end+1) =  fscanf(fid,'%i',[1 1]);
+    end
+
 	BRinfo.vertices(ii).type = fscanf(fid,'%i',[1 1]);
 
 	% this feature was introduced in v 1.8.0

--- a/matlab_codes/gather_br_samples.m
+++ b/matlab_codes/gather_br_samples.m
@@ -92,7 +92,7 @@ function md = gather_run_metadata(dirname)
 		md.version.subminor = str2num(md.version.string(pds(2)+1:end));
 		
 		md.version.number = 100*md.version.major + md.version.minor + 0.01 * md.version.subminor;
-		md.version.gather = 180;
+		md.version.gather = 190;
 	else
 		
 		md.version.string = 'earlier than 1.4';

--- a/matlab_codes/gather_br_samples.m
+++ b/matlab_codes/gather_br_samples.m
@@ -516,7 +516,7 @@ for ii = 1:BRinfo.num_vertices
     num_input_filename_indices = fscanf(fid,'%i\n',[1 1]);
     BRinfo.vertices(ii).all_input_filename_indices = zeros(num_input_filename_indices,1);
     for jj = 1:num_input_filename_indices
-        BRinfo.vertices(ii).all_input_filename_indices(end+1) =  fscanf(fid,'%i',[1 1]);
+        BRinfo.vertices(ii).all_input_filename_indices(jj) =  fscanf(fid,'%i',[1 1]);
     end
 
 	BRinfo.vertices(ii).type = fscanf(fid,'%i',[1 1]);

--- a/python/bertini_real/__about__.py
+++ b/python/bertini_real/__about__.py
@@ -1,4 +1,4 @@
-__version_info__ = (1, 8)
+__version_info__ = (1, 9)
 __version__ = '.'.join(map(str, __version_info__))
 
 __title__ = "bertini_real"

--- a/python/bertini_real/data/__init__.py
+++ b/python/bertini_real/data/__init__.py
@@ -105,12 +105,19 @@ def gather_vertices(directory):
             while line == '\n':
                 line = f.readline()
 
-            input_in = float(
-                line.replace('\n', ''))
-            line = f.readline()
+            filename_index = int(line.replace('\n', ''))
 
-            while line == '\n':
+
+            all_filename_indices = "feature added in 1.9, your data is too old.  run a new decomposition using 1.9 or higher"
+            if bertini_real.__version_info__ >= (1,9):
                 line = f.readline()
+                num_filename_indices = int(line)
+                line = f.readline()
+                all_filename_indices = [int(n) for n in line.split()]
+                if len(all_filename_indices) != num_filename_indices:
+                    raise RuntimeError(f"incorrect number of filename indices read, expected {num_filename_indices} but got {len(all_filename_indices)}")
+            
+            line = f.readline()
 
             vertextype = int(line.replace('\n', ''))
 
@@ -121,8 +128,7 @@ def gather_vertices(directory):
                 line = f.readline()
                 path_numbers_ending_here = [int(n) for n in line.split()]
 
-            v = Vertex(point, input_in, proj, vertextype, path_numbers_ending_here)
-            vertices[ii] = v
+            vertices[ii] = Vertex(point, filename_index, proj, vertextype, path_numbers_ending_here, all_filename_indices)
 
         return vertices, filenames
 

--- a/python/bertini_real/vertex/__init__.py
+++ b/python/bertini_real/vertex/__init__.py
@@ -40,7 +40,7 @@ class Vertex:
 
     """
 
-    def __init__(self, point, input_filename_index, projection_value, vertex_type, path_numbers_ending_here):
+    def __init__(self, point, input_filename_index, projection_value, vertex_type, path_numbers_ending_here, all_filename_indices):
         """ Initialize a Vertex object
 
             :param point: coordinates
@@ -54,10 +54,11 @@ class Vertex:
         self.projection_value = projection_value
         self.type = VertexType(vertex_type)
         self.path_numbers_ending_here = path_numbers_ending_here
+        self.all_filename_indices = all_filename_indices
 
     def __repr__(self):
         """ toString method for Vertex """
-        val = f"Vertex({self.point},{self.input_filename_index},{self.type},{self.path_numbers_ending_here})"
+        val = f"Vertex({self.point},{self.input_filename_index},{self.type},{self.path_numbers_ending_here},{self.all_filename_indices})"
         return val
 
     def __str__(self):

--- a/src/cells/vertex.cpp
+++ b/src/cells/vertex.cpp
@@ -11,40 +11,57 @@ void Vertex::set_point(const vec_mp new_point)
 
 void Vertex::send(int target, ParallelismConfig & mpi_config) const
 {
+	// std::cout << "send vertex to " << target << std::endl;
 
 	send_vec_mp(pt_mp_, target);
 
 	send_vec_mp(projection_values_, target);
 
-	int * buffer = (int *) br_malloc(2*sizeof(int));
+	int * buffer = new int[4];
 	buffer[0] = type_;
 	buffer[1] = input_filename_index_;
+	buffer[2] = input_filename_indices_.size();
+	buffer[3] = path_numbers_ending_here_.size();
 
-	MPI_Send(buffer, 2, MPI_INT, target, VERTEX, mpi_config.comm());
+	MPI_Send(buffer, 4, MPI_INT, target, VERTEX, mpi_config.comm());
 
-	// send the path numbers v1.8.0
+	MPI_Send(&input_filename_indices_.front(),     input_filename_indices_.size(), MPI_INT, target, VERTEX, mpi_config.comm());
+	
+	MPI_Send(&path_numbers_ending_here_.front(), path_numbers_ending_here_.size(), MPI_INT, target, VERTEX, mpi_config.comm());
 
 
-	free(buffer);
+
+	delete[] buffer;
 
 }
 
 
 void Vertex::receive(int source, ParallelismConfig & mpi_config)
 {
-	MPI_Status statty_mc_gatty;
-	int * buffer = (int *) br_malloc(2*sizeof(int));
+	// std::cout << "recv vertex from " << source << std::endl;
 
+	MPI_Status statty_mc_gatty;
 
 	receive_vec_mp(pt_mp_, source);
 	receive_vec_mp(projection_values_, source);
 
-	MPI_Recv(buffer, 2, MPI_INT, source, VERTEX, mpi_config.comm(), &statty_mc_gatty);
+
+	int * buffer = new int[4];
+
+	MPI_Recv(buffer, 4, MPI_INT, source, VERTEX, mpi_config.comm(), &statty_mc_gatty);
 
 	type_ = static_cast<VertexType>(buffer[0]);
 	input_filename_index_ = buffer[1];
 
-	// need to receive the path numbers v1.8.0
+	int num_filename_indices = buffer[2];
+	int num_paths = buffer[3];
 
-	free(buffer);
+	input_filename_indices_.resize(num_filename_indices);
+	MPI_Recv(&input_filename_indices_.front(), num_filename_indices, MPI_INT, source, VERTEX, mpi_config.comm(), &statty_mc_gatty);
+		
+	path_numbers_ending_here_.resize(num_paths);
+	MPI_Recv(&path_numbers_ending_here_.front(), num_paths,          MPI_INT, source, VERTEX, mpi_config.comm(), &statty_mc_gatty);
+
+
+	delete[] buffer;
 }

--- a/src/containers/vertex_set.cpp
+++ b/src/containers/vertex_set.cpp
@@ -397,10 +397,21 @@ int VertexSet::setup_vertices(boost::filesystem::path INfile)
 			mpf_inp_str((temp_vertex.projection_values())->coord[jj].i, IN, 10);
 		}
 
+		// read the main filename index, this is the first system where this point was encountered
 		int temp_int;
 		fscanf(IN,"%d\n",&temp_int);
 		temp_vertex.set_input_filename_index(temp_int);
 
+
+		// read all the filename indices.  every time we find it, we record it.  the first should be `input_filename_index`
+		fscanf(IN,"%d\n",&tmp_num_filenames); // the number of indices
+		for (int ii=0; ii<tmp_num_filenames; ++ii)
+		{
+			fscanf(IN,"%d",&temp_int);
+			temp_vertex.add_input_filename_index(temp_int);
+		}
+
+		// read the type of the vertex.  silviana notes, the type should really be recorded per-input file, just having the type without this is loss of valuable information
 		fscanf(IN,"%d\n",&temp_int);
 	    temp_vertex.set_type(static_cast<VertexType>(temp_int)); // i believe that this is wrong -- vertices which have multiple types will lose this property.  which one will they become?  i don't know.  --dab, 20191015
 
@@ -481,7 +492,7 @@ void VertexSet::print(boost::filesystem::path const& outputfile) const
 		fprintf(OUT,"%d\n",vertices_[ii].input_filename_index());
 
 		// added in 1.9
-		fprintf(OUT,"%d\n",vertices_[ii].input_filename_indices().size());
+		fprintf(OUT,"%zu\n",vertices_[ii].input_filename_indices().size());
 		for (auto ind : vertices_[ii].input_filename_indices())
 			fprintf(OUT,"%d",ind);
 		fprintf(OUT,"\n");

--- a/src/containers/vertex_set.cpp
+++ b/src/containers/vertex_set.cpp
@@ -480,6 +480,13 @@ void VertexSet::print(boost::filesystem::path const& outputfile) const
 
 		fprintf(OUT,"%d\n",vertices_[ii].input_filename_index());
 
+		// added in 1.9
+		fprintf(OUT,"%d\n",vertices_[ii].input_filename_indices().size());
+		for (auto ind : vertices_[ii].input_filename_indices())
+			fprintf(OUT,"%d",ind);
+		fprintf(OUT,"\n");
+
+
 		// fprintf(OUT,"\n"); // removed 1.8.0.  i hope this doesn't cause problems.
 		fprintf(OUT,"%d\n",vertices_[ii].type());
 

--- a/src/containers/vertex_set.cpp
+++ b/src/containers/vertex_set.cpp
@@ -90,6 +90,11 @@ int VertexSet::search_for_removed_point(vec_mp const& testpoint)
 
 
 
+void VertexSet::add_current_input_index_to_vertex(unsigned int index)
+{
+	vertices_[index].add_input_filename_index(this->curr_input_index_);
+}
+
 
 int VertexSet::compute_downstairs_crit_midpts(const WitnessSet & W,
                                                vec_mp crit_downstairs,

--- a/src/containers/vertex_set.cpp
+++ b/src/containers/vertex_set.cpp
@@ -494,7 +494,7 @@ void VertexSet::print(boost::filesystem::path const& outputfile) const
 		// added in 1.9
 		fprintf(OUT,"%zu\n",vertices_[ii].input_filename_indices().size());
 		for (auto ind : vertices_[ii].input_filename_indices())
-			fprintf(OUT,"%d",ind);
+			fprintf(OUT,"%d ",ind);
 		fprintf(OUT,"\n");
 
 

--- a/src/containers/vertex_set.cpp
+++ b/src/containers/vertex_set.cpp
@@ -306,6 +306,7 @@ int VertexSet::add_vertex(const Vertex & source_vertex, SolutionMetadata const& 
 	{
 		vertices_[num_vertices_].set_input_filename_index(curr_input_index_);
 	}
+	vertices_[num_vertices_].add_input_filename_index(curr_input_index_);
 
 
 	this->num_vertices_++;

--- a/src/decompositions/curve.cpp
+++ b/src/decompositions/curve.cpp
@@ -473,7 +473,7 @@ int Curve::interslice(const WitnessSet & W_curve,
 	SetCritSliceValues(crit_downstairs);
 
 	if (program_options.verbose_level()>=0) {
-		print_point_to_screen_matlab(crit_downstairs,"curve_interslice_crit_downstairs");
+		print_point_to_screen_matlab(crit_downstairs,"curve_interslice_crit_downstairs", 15);
 	}
 
 

--- a/src/decompositions/decomposition.cpp
+++ b/src/decompositions/decomposition.cpp
@@ -69,6 +69,8 @@ int Decomposition::index_in_vertices_with_add(VertexSet &V,
 		index = Decomposition::add_vertex(V, vert, meta);
 	}
 	else{
+		V.add_current_input_index_to_vertex(index);
+
 		for (auto n: meta.get_path_numbers_absolute())
 			V[index].add_path_number_ending_here(n);
 	}

--- a/src/nag/witness_set.cpp
+++ b/src/nag/witness_set.cpp
@@ -68,10 +68,10 @@ void SolutionMetadata::send(int target, ParallelismConfig & mpi_config) const
 
     MPI_Send(buffer, 9, MPI_LONG_LONG, target, SOLUTION_METADATA, mpi_config.comm());
 
-    delete[] buffer;
 
     MPI_Send(&path_numbers_zero_based[0], path_numbers_zero_based.size(), MPI_LONG_LONG, target, SOLUTION_METADATA, mpi_config.comm());
     MPI_Send(&path_numbers_absolute[0], path_numbers_absolute.size(), MPI_LONG_LONG, target, SOLUTION_METADATA, mpi_config.comm());
+    delete[] buffer;
 
     return;
 }
@@ -95,10 +95,11 @@ void SolutionMetadata::receive(int source, ParallelismConfig & mpi_config)
     is_real = buffer[7];
     cycle_number_ = buffer[8];
 
-    delete[] buffer; 
 
     MPI_Recv(&path_numbers_zero_based[0], buffer[0], MPI_LONG_LONG, source, SOLUTION_METADATA, mpi_config.comm(), &statty_mc_gatty);
     MPI_Recv(&path_numbers_absolute[0], buffer[1], MPI_LONG_LONG, source, SOLUTION_METADATA, mpi_config.comm(), &statty_mc_gatty);
+
+    delete[] buffer; 
 
     return;
 }

--- a/src/nag/witness_set.cpp
+++ b/src/nag/witness_set.cpp
@@ -55,8 +55,7 @@ void SolutionMetadata::send(int target, ParallelismConfig & mpi_config) const
 {
     //send all the data to the other party
 
-
-    long long *buffer = (long long *) br_malloc(9*sizeof(long long));
+    long long *buffer = new long long[9];
     buffer[0] = path_numbers_zero_based.size();
     buffer[1] = path_numbers_absolute.size();
     buffer[2] = output_index;
@@ -67,12 +66,12 @@ void SolutionMetadata::send(int target, ParallelismConfig & mpi_config) const
     buffer[7] = is_real;
     buffer[8] = cycle_number_;
 
-    MPI_Send(buffer, 9, MPI_LONG_LONG, SOLUTION_METADATA, target, mpi_config.comm());
+    MPI_Send(buffer, 9, MPI_LONG_LONG, target, SOLUTION_METADATA, mpi_config.comm());
 
-    free(buffer);
+    delete[] buffer;
 
-    MPI_Send(&path_numbers_zero_based[0], path_numbers_zero_based.size(), MPI_LONG_LONG, SOLUTION_METADATA, target, mpi_config.comm());
-    MPI_Send(&path_numbers_absolute[0], path_numbers_absolute.size(), MPI_LONG_LONG, SOLUTION_METADATA, target, mpi_config.comm());
+    MPI_Send(&path_numbers_zero_based[0], path_numbers_zero_based.size(), MPI_LONG_LONG, target, SOLUTION_METADATA, mpi_config.comm());
+    MPI_Send(&path_numbers_absolute[0], path_numbers_absolute.size(), MPI_LONG_LONG, target, SOLUTION_METADATA, mpi_config.comm());
 
     return;
 }
@@ -81,9 +80,9 @@ void SolutionMetadata::receive(int source, ParallelismConfig & mpi_config)
 {
     MPI_Status statty_mc_gatty;
 
-	int *buffer = new int[9];
+	long long *buffer = new long long[9];
 
-    MPI_Recv(buffer, 9, MPI_LONG_LONG, SOLUTION_METADATA, source, mpi_config.comm(), &statty_mc_gatty);
+    MPI_Recv(buffer, 9, MPI_LONG_LONG, source, SOLUTION_METADATA, mpi_config.comm(), &statty_mc_gatty);
 
     path_numbers_zero_based.resize(buffer[0]);
     path_numbers_absolute.resize(buffer[1]);
@@ -96,10 +95,10 @@ void SolutionMetadata::receive(int source, ParallelismConfig & mpi_config)
     is_real = buffer[7];
     cycle_number_ = buffer[8];
 
-    MPI_Recv(&path_numbers_zero_based[0], buffer[0], MPI_LONG_LONG, SOLUTION_METADATA, source, mpi_config.comm(), &statty_mc_gatty);
-    MPI_Recv(&path_numbers_absolute[0], buffer[1], MPI_LONG_LONG, SOLUTION_METADATA, source, mpi_config.comm(), &statty_mc_gatty);
+    delete[] buffer; 
 
-    delete[] buffer; // silviana, it makes me angry that in the send you malloc, and here you delete.  this sucks.
+    MPI_Recv(&path_numbers_zero_based[0], buffer[0], MPI_LONG_LONG, source, SOLUTION_METADATA, mpi_config.comm(), &statty_mc_gatty);
+    MPI_Recv(&path_numbers_absolute[0], buffer[1], MPI_LONG_LONG, source, SOLUTION_METADATA, mpi_config.comm(), &statty_mc_gatty);
 
     return;
 }

--- a/test/surface/whitney/demoplot.m
+++ b/test/surface/whitney/demoplot.m
@@ -1,0 +1,2 @@
+gather_br_samples
+bertini_real_plotter


### PR DESCRIPTION
when computing something with bertini_real, it would be nice to know which systems a point lives on, all of them.  up to this point, we only knew the FIRST system a point lived on.  This PR brings a partial implementation of this upgrade.  Namely, when we look in a vertex set for a point (with add), we also record the system that is set in the vertex set.

This PR also fixes some MPI bugs that got introduced when I added path number stuff.